### PR TITLE
Add Claude code settings with custom plugin marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+
+  "extraKnownMarketplaces": {
+    "laurigates-claude-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "laurigates/claude-plugins",
+        "ref": "main"
+      }
+    }
+  },
+
+  "enabledPlugins": {
+    "rust-plugin@laurigates-claude-plugins": true,
+    "typescript-plugin@laurigates-claude-plugins": true,
+    "testing-plugin@laurigates-claude-plugins": true,
+    "code-quality-plugin@laurigates-claude-plugins": true,
+    "git-plugin@laurigates-claude-plugins": true,
+    "configure-plugin@laurigates-claude-plugins": true,
+    "agents-plugin@laurigates-claude-plugins": true,
+    "github-actions-plugin@laurigates-claude-plugins": true,
+    "documentation-plugin@laurigates-claude-plugins": true,
+    "tools-plugin@laurigates-claude-plugins": true,
+    "blueprint-plugin@laurigates-claude-plugins": true,
+    "api-plugin@laurigates-claude-plugins": true
+  },
+
+  "enableAllProjectMcpServers": true
+}


### PR DESCRIPTION
## Summary
This PR adds a `.claude/settings.json` configuration file to enable and configure Claude plugins for the project.

## Changes
- Created `.claude/settings.json` with schema reference to `claude-code-settings.json`
- Configured a custom plugin marketplace (`laurigates-claude-plugins`) pointing to the `laurigates/claude-plugins` GitHub repository
- Enabled 12 plugins from the custom marketplace:
  - Language support: Rust, TypeScript
  - Development tools: Testing, Code Quality, Git, GitHub Actions
  - Project management: Configure, Agents, Documentation, Tools, Blueprint, API
- Enabled all project MCP (Model Context Protocol) servers

## Implementation Details
- The configuration uses a GitHub-based marketplace source, allowing plugins to be versioned and maintained in a separate repository
- All plugins are explicitly enabled to provide comprehensive development tooling support
- The `enableAllProjectMcpServers` flag ensures all available MCP servers are active for enhanced IDE capabilities

https://claude.ai/code/session_01An6aiAfKdatRGbwtDt8Smh